### PR TITLE
Add tray icon, drop pynput, harden background loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,7 @@ Just install exe and run it whethever you want and it will install it in user fo
 Just go to path: `%localappdata%\SRR` and edit `config.json`(using notepad or whatever). Programm will auto accept changes.
 
 ### What if i want to close this program?
-Just press `right shift + backspace` to terminate SRR.
+SRR runs with a system tray icon. Right-click it and choose **Exit**. From the same menu you can pause/resume the service, reload `config.json`, open the config folder or logs, and toggle **Run at startup** to remove SRR from Windows autostart.
+
+### How heavy is it on the CPU?
+SRR polls power state once every 5 seconds and only reads `config.json` when its mtime changes (or on demand from the tray menu), so idle CPU usage is effectively 0%.

--- a/autostart.py
+++ b/autostart.py
@@ -1,0 +1,57 @@
+"""Windows autostart management via HKCU Run registry key."""
+import logging
+from pathlib import Path
+
+try:
+    import winreg
+except ImportError:
+    winreg = None
+
+RUN_KEY = r"Software\Microsoft\Windows\CurrentVersion\Run"
+
+
+def _open(access):
+    return winreg.OpenKey(winreg.HKEY_CURRENT_USER, RUN_KEY, 0, access)
+
+
+def is_enabled(name: str) -> bool:
+    if winreg is None:
+        return False
+    try:
+        with _open(winreg.KEY_READ) as key:
+            winreg.QueryValueEx(key, name)
+            return True
+    except FileNotFoundError:
+        return False
+    except OSError as e:
+        logging.warning(f"autostart.is_enabled failed: {e}")
+        return False
+
+
+def enable(name: str, exe_path: Path) -> bool:
+    if winreg is None:
+        return False
+    quoted = f'"{Path(exe_path).resolve()}"'
+    try:
+        with _open(winreg.KEY_SET_VALUE) as key:
+            winreg.SetValueEx(key, name, 0, winreg.REG_SZ, quoted)
+        logging.info(f"autostart enabled: {name} -> {quoted}")
+        return True
+    except OSError as e:
+        logging.error(f"autostart.enable failed: {e}")
+        return False
+
+
+def disable(name: str) -> bool:
+    if winreg is None:
+        return False
+    try:
+        with _open(winreg.KEY_SET_VALUE) as key:
+            winreg.DeleteValue(key, name)
+        logging.info(f"autostart disabled: {name}")
+        return True
+    except FileNotFoundError:
+        return True
+    except OSError as e:
+        logging.error(f"autostart.disable failed: {e}")
+        return False

--- a/main.py
+++ b/main.py
@@ -1,26 +1,25 @@
+import asyncio
+import ctypes
 import dataclasses
 import json
 import logging
+import logging.handlers
 import os
-import sys
-import psutil
 import shutil
-import ctypes
-import asyncio
-
+import sys
 from pathlib import Path
-from pynput import keyboard
-from typing import Union, Dict, SupportsInt, AnyStr, Tuple, List, Optional
+from typing import AnyStr, Dict, Optional, SupportsInt, Tuple
 
-from reschanger import DISP_RESULTS
+import psutil
+
+import autostart
 import reschanger
-
-Keys = keyboard.Key
-last_btn: Keys
+from reschanger import DISP_RESULTS
+from tray import TrayController
 
 # constants
-TIME_STEP = 1  # seconds
-STARTUP_SWITCH = True
+TIME_STEP = 5  # seconds; raised from 1 to reduce idle CPU usage
+CONFIG_RELOAD_EVERY = 6  # iterations -> ~30 s
 
 PROJECT_NAME = "SRR"
 PROJECT_EXECUTABLE = PROJECT_NAME + ".exe"
@@ -29,7 +28,14 @@ PATH_APPDATA_LOCAL = Path(os.getenv("LOCALAPPDATA")).resolve()
 PATH_TO_PROGRAM = PATH_APPDATA_LOCAL / PROJECT_NAME
 PATH_CURRENT_FILE = Path(sys.argv[0]).resolve()
 PATH_BASE_DIR = PATH_CURRENT_FILE.parent
-PATH_REG_AUTORUN = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run"
+PATH_CONFIG = PATH_TO_PROGRAM / "config.json"
+PATH_LOG = PATH_TO_PROGRAM / "logs.txt"
+PATH_ICON = PATH_BASE_DIR / "assets" / "srr.ico"
+
+# runtime state
+_shutdown_event: Optional[asyncio.Event] = None
+_reload_event: Optional[asyncio.Event] = None
+_tray: Optional[TrayController] = None
 
 config_last_state = None
 config_last_update = None
@@ -45,87 +51,66 @@ class ScreenSettings:
         return iter([self.width, self.height, self.refresh_rate])
 
 
-def write_logs(e: Union[Exception, BaseException]):
-    logging.info("Writing logs")
-
-    logging.error(f"Error occurred: {str(e)}", exc_info=e)
-
-    ctypes.windll.user32.MessageBoxW(
-        None, f"The SRR program terminated with the following error:\n{str(e)}", "Error", 0x00000010,
-    )
-
-
-def on_press(key):
-    global last_btn
-    if key != Keys.backspace:
-        last_btn = key
+def write_logs(e: BaseException, show_dialog: bool = True):
+    logging.error(f"Error occurred: {e}", exc_info=e)
+    if show_dialog:
+        try:
+            ctypes.windll.user32.MessageBoxW(
+                None,
+                f"The SRR program terminated with the following error:\n{e}",
+                "Error",
+                0x00000010,
+            )
+        except Exception:
+            pass
 
 
-def on_release(key):
-    if key == Keys.backspace and last_btn == Keys.shift_r:
-        reschanger.set_display_defaults()
-        logging.info("Display settings were reset to default and the program was terminated")
-        write_logs(Exception("Program termination caused by user"))
-        os._exit(-3)
-
-
-def cur_power_state():
-    return psutil.sensors_battery().power_plugged
+def cur_power_state() -> Optional[bool]:
+    """Returns True if AC, False if on battery, None if no battery info."""
+    try:
+        bat = psutil.sensors_battery()
+    except Exception as e:
+        logging.warning(f"sensors_battery failed: {e}")
+        return None
+    if bat is None:
+        return None
+    return bool(bat.power_plugged)
 
 
 def cur_monitor_specs() -> Dict[AnyStr, Dict[AnyStr, SupportsInt]]:
-    """
-    Get current monitor specs and return it as dictionary with two states: 'powersave-state' and 'performance-state'
-
-    :return: A dictionary with two states: 'powersave-state' and 'performance-state'
-             'powersave-state' and 'performance-state' are dictionary with keys 'width', 'height', and 'refresh_rate'
-             'width' and 'height' are screen resolution
-             'refresh_rate' is screen refresh rate
-    """
-
     logging.info("Getting current monitor specs")
-    width, height, refresh_rate_max, refresh_rate_min = reschanger.get_resolution()
-    params = {
-        "powersave-state": {
-            "width": width,
-            "height": height,
-            "refresh_rate": refresh_rate_min,
-        },
-        "performance-state": {
-            "width": width,
-            "height": height,
-            "refresh_rate": refresh_rate_max,
-        },
+    width, height, rr_max, rr_min = reschanger.get_resolution()
+    return {
+        "powersave-state": {"width": width, "height": height, "refresh_rate": rr_min},
+        "performance-state": {"width": width, "height": height, "refresh_rate": rr_max},
     }
-    return params
 
 
-async def load_config() -> Optional[Tuple[ScreenSettings, ScreenSettings]]:
-    logging.debug(f"Loading config from {PATH_TO_PROGRAM / 'config.json'}")
-
-    update_time = os.path.getmtime(PATH_TO_PROGRAM / 'config.json')
-
+async def load_config(force: bool = False) -> Optional[Tuple[ScreenSettings, ScreenSettings]]:
     global config_last_state, config_last_update
+    try:
+        update_time = os.path.getmtime(PATH_CONFIG)
+    except OSError as e:
+        logging.error(f"config not accessible: {e}")
+        return config_last_state
 
-    if config_last_update == update_time:
+    if not force and config_last_update == update_time:
+        return config_last_state
+
+    try:
+        with open(PATH_CONFIG, "r") as f:
+            params = json.load(f)
+        performance_state = ScreenSettings(**params["performance-state"])
+        powersave_state = ScreenSettings(**params["powersave-state"])
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        logging.error(f"config parse failed, keeping previous: {e}")
+        if _tray is not None:
+            _tray.notify("config.json is invalid — keeping previous settings.")
         return config_last_state
 
     config_last_update = update_time
-
-    with open(PATH_TO_PROGRAM / "config.json", "r") as config:
-        stream = config.read()
-
-        params = json.JSONDecoder().decode(stream)
-
-        performance_dict = params["performance-state"]
-        performance_state = ScreenSettings(**performance_dict)
-
-        powersave_dict = params["powersave-state"]
-        powersave_state = ScreenSettings(**powersave_dict)
-
-        config_last_state = performance_state, powersave_state
-
-        return performance_state, powersave_state
+    config_last_state = (performance_state, powersave_state)
+    return config_last_state
 
 
 async def change_screen_settings(ss: ScreenSettings) -> None:
@@ -133,168 +118,194 @@ async def change_screen_settings(ss: ScreenSettings) -> None:
     res = reschanger.set_resolution(*ss)
 
     if res == DISP_RESULTS.DISP_CHANGE_BADPARAM:
+        msg = "Parameters in config.json are not a supported display mode."
+        logging.error(msg)
+        if _tray is not None:
+            _tray.notify(msg)
+        return
 
-        ctypes.windll.user32.MessageBoxW(
-            None, "Your parameters wrote in config.json were incorrect.\nCheck log file for available modes.",
-            "Resolution Changing Info", 0x00000010
-        )
-        write_logs(Exception("\n".join(
-            [
-                "Your parameters wrote in config.json were incorrect.",
-                *reschanger.get_resolutions()
-            ]
-        )))
+    if res != DISP_RESULTS.DISP_CHANGE_SUCCESSFUL:
+        logging.warning(f"set_resolution returned {res}; retrying after 10s")
         await asyncio.sleep(10)
-
-    elif not res == DISP_RESULTS.DISP_CHANGE_SUCCESSFUL:
-
-        await asyncio.sleep(10)
-        # write_logs(Exception("\n".join(
-        #     [
-        #         "Failed to change screen settings.",
-        #         "This could be due to external interference(like graphic drives)",
-        #         "or the laptop being in a lockscreen or sleep state,",
-        #         "as Windows may prevent changes in those states."
-        #     ]
-        # )))
         reschanger.set_resolution(*ss)
 
 
-async def switch_rate(current_state: bool, prss: ScreenSettings, psss: ScreenSettings):
-    if current_state:
-        await change_screen_settings(prss)
-    else:
-        await change_screen_settings(psss)
+async def switch_rate(current_state: Optional[bool], prss: ScreenSettings, psss: ScreenSettings):
+    if current_state is None:
+        return
+    await change_screen_settings(prss if current_state else psss)
 
 
-async def srr_loop(time_step: int) -> None:
-    """
-    This function is an infinite loop that runs every `time_step` seconds and
-    checks the current power state and the current configuration. If the power
-    state or the configuration has changed, it will switch the screen settings
-    accordingly.
-    """
+def _state_label(state: Optional[bool]) -> str:
+    if state is None:
+        return "no battery info"
+    return "AC (performance)" if state else "Battery (powersave)"
+
+
+async def srr_loop() -> None:
     last_state = cur_power_state()
-
     current_config = await load_config()
-    prev_config_state = current_config
-
+    if _tray is not None:
+        _tray.set_state_text(_state_label(last_state))
     counter = 0
 
-    while True:
-        await asyncio.sleep(time_step)
+    while not _shutdown_event.is_set():
+        try:
+            await asyncio.wait_for(_shutdown_event.wait(), timeout=TIME_STEP)
+            break
+        except asyncio.TimeoutError:
+            pass
+
+        if _reload_event.is_set():
+            _reload_event.clear()
+            current_config = await load_config(force=True)
+            if current_config is not None:
+                await switch_rate(cur_power_state(), *current_config)
+
+        if _tray is not None and _tray.paused:
+            continue
 
         current_state = cur_power_state()
 
-        # I think opening config file every second is not a good idea,
-        # so then I made it in 10 time longer to wait.
-        if counter == 10:
-            logging.debug(f"Counter now = {counter}, reloading config")
-            current_config = await load_config()
-            if prev_config_state != current_config:
-                ctypes.windll.user32.MessageBoxW(
-                    None, "The SRR config was reloaded!", "Info", 0x00000040
-                )
-                await switch_rate(current_state, *current_config)
-
-            prev_config_state = current_config
+        if counter >= CONFIG_RELOAD_EVERY:
             counter = 0
-
-        if last_state != current_state:
-            await switch_rate(current_state, *current_config)
-
-        last_state = current_state
+            new_config = await load_config()
+            if new_config is not None and new_config != current_config:
+                current_config = new_config
+                if _tray is not None:
+                    _tray.notify("Config reloaded.")
+                await switch_rate(current_state, *current_config)
         counter += 1
 
+        if current_state != last_state and current_config is not None:
+            await switch_rate(current_state, *current_config)
+            if _tray is not None:
+                _tray.set_state_text(_state_label(current_state))
 
-async def get_processes(app_name: AnyStr) -> List[psutil.Process]:
-    # returns all processes with given name except the current process
-    processes = psutil.process_iter()
-    srr_instances = list(filter(lambda process: process.name() == app_name, processes))
-    filtered_instances = list(
-        filter(
-            lambda process: (process.exe() != str(PATH_CURRENT_FILE) and process.pid != os.getpid()),
-            srr_instances
-        )
+        last_state = current_state
+
+
+async def get_processes(app_name: AnyStr):
+    out = []
+    for p in psutil.process_iter(["pid", "name", "exe"]):
+        try:
+            if p.info["name"] != app_name:
+                continue
+            if p.info["exe"] == str(PATH_CURRENT_FILE) or p.pid == os.getpid():
+                continue
+            out.append(p)
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+    return out
+
+
+async def install():
+    """Copy exe into %LOCALAPPDATA%\\SRR, register autostart, restart from there."""
+    if PATH_BASE_DIR == PATH_TO_PROGRAM:
+        return
+    if PATH_CURRENT_FILE.suffix.lower() != ".exe":
+        return
+
+    logging.info("Installer: relocating to %s", PATH_TO_PROGRAM)
+
+    for inst in await get_processes(PROJECT_EXECUTABLE):
+        try:
+            inst.kill()
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+    await asyncio.sleep(2)
+
+    PATH_TO_PROGRAM.mkdir(parents=True, exist_ok=True)
+    target_exe = PATH_TO_PROGRAM / PROJECT_EXECUTABLE
+    try:
+        shutil.copy2(PATH_CURRENT_FILE, target_exe)
+    except OSError as e:
+        logging.error(f"copy to {target_exe} failed: {e}")
+        raise
+
+    autostart.enable(PROJECT_NAME, target_exe)
+
+    try:
+        os.startfile(str(target_exe))
+    except OSError as e:
+        logging.error(f"failed to launch installed copy: {e}")
+        raise
+
+    ctypes.windll.user32.MessageBoxW(
+        None,
+        "SRR was installed and now runs in background. A tray icon will appear.",
+        "Info",
+        0x00000040,
     )
+    sys.exit(0)
 
-    logging.debug("Current process:" + str(PATH_CURRENT_FILE))
-    logging.debug("All instances:")
-    for instance in srr_instances.copy():
-        logging.debug(f"{instance.name()}: {instance.pid} - {instance.exe()}")
 
-    logging.debug("Filtered instances:")
-    for instance in filtered_instances.copy():
-        logging.debug(f"{instance.name()}: {instance.pid} - {instance.exe()}")
-    return filtered_instances
+def _ensure_config():
+    if not PATH_CONFIG.exists():
+        logging.info("creating default config.json")
+        with open(PATH_CONFIG, "w") as f:
+            json.dump(cur_monitor_specs(), f, indent=4)
 
 
 async def srr():
-    # program "installer":
-    # adding program to its destination and to startup
-    logging.info("Program started")
+    PATH_TO_PROGRAM.mkdir(parents=True, exist_ok=True)
+    await install()
+    _ensure_config()
 
-    if PATH_BASE_DIR != PATH_TO_PROGRAM:
+    global _shutdown_event, _reload_event, _tray
+    loop = asyncio.get_running_loop()
+    _shutdown_event = asyncio.Event()
+    _reload_event = asyncio.Event()
 
-        logging.info(f"{PATH_BASE_DIR} and {PATH_TO_PROGRAM} are not the same")
-        if PATH_CURRENT_FILE.suffix == ".exe":
-            logging.info(f"{PROJECT_EXECUTABLE} is an exe file")
+    def _request_exit():
+        logging.info("shutdown requested")
+        try:
+            reschanger.set_display_defaults()
+        except Exception as e:
+            logging.warning(f"set_display_defaults failed: {e}")
+        loop.call_soon_threadsafe(_shutdown_event.set)
 
-            # kill all processes except the current one
-            for instance in await get_processes(PROJECT_EXECUTABLE):
-                instance.kill()
+    def _request_reload():
+        loop.call_soon_threadsafe(_reload_event.set)
 
-            await asyncio.sleep(2)
+    _tray = TrayController(
+        project_name=PROJECT_NAME,
+        exe_path=PATH_TO_PROGRAM / PROJECT_EXECUTABLE,
+        config_path=PATH_CONFIG,
+        log_path=PATH_LOG,
+        on_exit=_request_exit,
+        on_reload=_request_reload,
+        icon_path=PATH_ICON if PATH_ICON.exists() else None,
+    )
+    _tray.start()
 
-            logging.info(f"All {PROJECT_EXECUTABLE} processes were killed except current one")
-            logging.info(f"Live processes: {await get_processes(PROJECT_EXECUTABLE)}")
+    cfg = await load_config()
+    if cfg is not None:
+        await switch_rate(cur_power_state(), *cfg)
 
-            shutil.rmtree(PATH_TO_PROGRAM)
-            logging.info(f"{PATH_TO_PROGRAM} was removed")
-
-            PATH_TO_PROGRAM.mkdir(parents=True, exist_ok=True)
-            shutil.copy(PATH_CURRENT_FILE, PATH_TO_PROGRAM / PROJECT_EXECUTABLE)
-            logging.info(f"{PROJECT_EXECUTABLE} was copied to {PATH_TO_PROGRAM}")
-
-            # os.system(f'sc create SRR-service binpath="{PATH_TO_PROGRAM / PROJECT_EXECUTABLE}" start=delayed-auto')
-
-            os.system(f"reg add HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Run /v "
-                      f"{PROJECT_NAME} /t REG_SZ /d {PATH_TO_PROGRAM / PROJECT_EXECUTABLE} /f")
-            logging.info(f"{PROJECT_EXECUTABLE} was added to autorun")
-
-            os.startfile(PATH_TO_PROGRAM / PROJECT_EXECUTABLE)
-            logging.info(f"{PROJECT_EXECUTABLE} is not running, so it was started")
-            logging.info(f"{PATH_CURRENT_FILE} terminating itself")
-            ctypes.windll.user32.MessageBoxW(
-                None, "The SRR was successfully installed! Now it runs in background.", "Info", 0x00000040
-            )
-            os._exit(0)
-
-    # create config file if it doesn't exist
-    if not Path.exists(PATH_TO_PROGRAM / "config.json"):
-        logging.info("Config file was not found, so it was created")
-        with open(PATH_TO_PROGRAM / "config.json", "w") as config:
-            params = cur_monitor_specs()
-            json.dump(params, config, indent=4)
-
-    # start infinite loop
-    with keyboard.Listener(on_press=on_press, on_release=on_release, suppress=False):
-        logging.info("Starting infinite loop")
-        await switch_rate(cur_power_state(), *(await load_config()))
-        await srr_loop(TIME_STEP)
+    await srr_loop()
 
 
 async def main():
-    # catching all possible exceptions and exiting with error code -1
     try:
         await srr()
     except Exception as e:
         write_logs(e)
-        os._exit(-1)
+        sys.exit(1)
+
+
+def _setup_logging():
+    PATH_TO_PROGRAM.mkdir(parents=True, exist_ok=True)
+    handler = logging.handlers.RotatingFileHandler(
+        PATH_LOG, maxBytes=1_000_000, backupCount=3, encoding="utf-8"
+    )
+    logging.basicConfig(
+        level=logging.INFO,
+        handlers=[handler],
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
 
 
 if __name__ == "__main__":
-    if not PATH_TO_PROGRAM.exists():
-        PATH_TO_PROGRAM.mkdir()
-    logging.basicConfig(level=logging.INFO, filename=PATH_BASE_DIR / "logs.txt", filemode="w")
+    _setup_logging()
     asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 psutil
-pynput
+pystray
+Pillow

--- a/reschanger.py
+++ b/reschanger.py
@@ -136,15 +136,29 @@ def get_primary_device():
     return dd
 
 
-def get_resolutions():
-    """Gets all available resolutions"""
+_resolutions_cache = None
+
+
+def _enum_resolutions():
     dm = DEVMODE()
     dm.dmSize = ctypes.sizeof(dm)
     i_mode_num = 0
-
     while user32.EnumDisplaySettingsA(None, i_mode_num, ctypes.pointer(dm)) != 0:
         yield dm.dmPelsWidth, dm.dmPelsHeight, dm.dmDisplayFrequency
         i_mode_num += 1
+
+
+def get_resolutions():
+    """Gets all available resolutions (cached)."""
+    global _resolutions_cache
+    if _resolutions_cache is None:
+        _resolutions_cache = tuple(_enum_resolutions())
+    return _resolutions_cache
+
+
+def invalidate_resolutions_cache():
+    global _resolutions_cache
+    _resolutions_cache = None
 
 
 def get_resolution():
@@ -199,7 +213,7 @@ def set_resolution(width, height, freq) -> int:
     if not user32.EnumDisplaySettingsA(dd.DeviceName, ENUM_CURRENT_SETTINGS, ctypes.pointer(dm)):
         raise Exception("Failed to get display settings.")
 
-    if (width, height, freq) not in list(get_resolutions()):
+    if (width, height, freq) not in get_resolutions():
         return DISP_RESULTS.DISP_CHANGE_BADPARAM
 
     dm.dmPelsWidth = width

--- a/tray.py
+++ b/tray.py
@@ -1,0 +1,145 @@
+"""System tray icon for SRR. Runs pystray in a separate thread."""
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Callable, Optional
+
+import pystray
+from PIL import Image, ImageDraw
+
+import autostart
+
+
+def _make_default_icon() -> Image.Image:
+    img = Image.new("RGB", (64, 64), (30, 30, 30))
+    d = ImageDraw.Draw(img)
+    d.rectangle((8, 18, 56, 46), outline=(120, 200, 255), width=3)
+    d.line((20, 32, 44, 32), fill=(120, 200, 255), width=2)
+    d.rectangle((24, 48, 40, 52), fill=(120, 200, 255))
+    return img
+
+
+def _load_icon(icon_path: Optional[Path]) -> Image.Image:
+    if icon_path and icon_path.exists():
+        try:
+            return Image.open(str(icon_path))
+        except Exception as e:
+            logging.warning(f"failed to load tray icon {icon_path}: {e}")
+    return _make_default_icon()
+
+
+class TrayController:
+    """
+    Owns the pystray icon. The async loop reads `paused` and `state_text`,
+    and triggers `reload_event` / `shutdown_event`.
+    """
+
+    def __init__(
+        self,
+        project_name: str,
+        exe_path: Path,
+        config_path: Path,
+        log_path: Path,
+        on_exit: Callable[[], None],
+        on_reload: Callable[[], None],
+        icon_path: Optional[Path] = None,
+    ):
+        self.project_name = project_name
+        self.exe_path = exe_path
+        self.config_path = config_path
+        self.log_path = log_path
+        self._on_exit = on_exit
+        self._on_reload = on_reload
+
+        self.paused = False
+        self.state_text = "starting…"
+
+        self._icon_image = _load_icon(icon_path)
+        self._icon: Optional[pystray.Icon] = None
+        self._thread: Optional[threading.Thread] = None
+
+    # --- menu actions -------------------------------------------------
+
+    def _toggle_pause(self, icon, item):
+        self.paused = not self.paused
+        logging.info(f"tray: paused={self.paused}")
+        icon.update_menu()
+
+    def _reload(self, icon, item):
+        logging.info("tray: reload config requested")
+        self._on_reload()
+
+    def _open_config_dir(self, icon, item):
+        try:
+            os.startfile(str(self.config_path.parent))
+        except OSError as e:
+            logging.error(f"open config dir failed: {e}")
+
+    def _open_logs(self, icon, item):
+        try:
+            os.startfile(str(self.log_path))
+        except OSError as e:
+            logging.error(f"open logs failed: {e}")
+
+    def _toggle_autostart(self, icon, item):
+        if autostart.is_enabled(self.project_name):
+            autostart.disable(self.project_name)
+        else:
+            autostart.enable(self.project_name, self.exe_path)
+        icon.update_menu()
+
+    def _exit(self, icon, item):
+        logging.info("tray: exit requested")
+        self._on_exit()
+        icon.stop()
+
+    # --- public api ---------------------------------------------------
+
+    def set_state_text(self, text: str):
+        self.state_text = text
+        if self._icon is not None:
+            try:
+                self._icon.update_menu()
+                self._icon.title = f"SRR — {text}"
+            except Exception:
+                pass
+
+    def notify(self, message: str, title: str = "SRR"):
+        if self._icon is not None:
+            try:
+                self._icon.notify(message, title)
+            except Exception as e:
+                logging.warning(f"tray notify failed: {e}")
+
+    def _build_menu(self) -> pystray.Menu:
+        return pystray.Menu(
+            pystray.MenuItem(lambda item: f"Status: {self.state_text}", None, enabled=False),
+            pystray.Menu.SEPARATOR,
+            pystray.MenuItem(
+                lambda item: "Resume" if self.paused else "Pause",
+                self._toggle_pause,
+            ),
+            pystray.MenuItem("Reload config", self._reload),
+            pystray.Menu.SEPARATOR,
+            pystray.MenuItem("Open config folder", self._open_config_dir),
+            pystray.MenuItem("Open logs", self._open_logs),
+            pystray.MenuItem(
+                "Run at startup",
+                self._toggle_autostart,
+                checked=lambda item: autostart.is_enabled(self.project_name),
+            ),
+            pystray.Menu.SEPARATOR,
+            pystray.MenuItem("Exit", self._exit),
+        )
+
+    def start(self):
+        self._icon = pystray.Icon(
+            self.project_name,
+            self._icon_image,
+            f"SRR — {self.state_text}",
+            menu=self._build_menu(),
+        )
+        self._thread = threading.Thread(target=self._icon.run, daemon=True, name="srr-tray")
+        self._thread.start()
+        logging.info("tray icon started")


### PR DESCRIPTION
- Tray icon (pystray) with Pause/Resume, Reload config, Open
  config/logs, Run-at-startup toggle, and proper Exit
- autostart.py: manage HKCU Run via winreg with quoted paths
- main.py: async shutdown via Event, install() preserves config,
  cur_power_state handles desktops (no battery), JSON parse
  errors no longer crash, rotating log handler, MessageBox on
  every state-change removed
- TIME_STEP raised from 1s to 5s; config reload only on mtime
  change or tray request
- reschanger: cache enumerated display modes; drop list() spam
- requirements: add pystray + Pillow, remove pynput